### PR TITLE
Use " for comments in ftdetect/nftables.vim

### DIFF
--- a/ftdetect/nftables.vim
+++ b/ftdetect/nftables.vim
@@ -1,5 +1,5 @@
-#
-# Detect file type by use of shebang
+"
+" Detect file type by use of shebang
 function! s:DetectFiletype()
     if getline(1) =~# '^#!\s*\%\(/\S\+\)\?/\%\(s\)\?bin/\%\(env\s\+\)\?nft\>'
         setfiletype nftables
@@ -8,9 +8,9 @@ endfunction
 
 augroup nftables
     autocmd!
-    # Detect file type by use of shebang
+    " Detect file type by use of shebang
     autocmd BufRead,BufNewFile * call s:DetectFiletype()
 
-    # Detect file type by its filetype
+    " Detect file type by its filetype
     autocmd BufRead,BufNewFile *.nft,nftables.conf setfiletype nftables
 augroup END


### PR DESCRIPTION
The `#` character is only recognized as a comment marker in Vim9 Script. Since `vim9script` is not set, use `"` for comments.

Fixes: #2

Thanks for considering,
Kevin